### PR TITLE
feat: Se crea Endpoint Para construir arbol rubro apropiacion para ag…

### DIFF
--- a/controllers/apropiacion.go
+++ b/controllers/apropiacion.go
@@ -105,6 +105,37 @@ func (c *ApropiacionController) ArbolApropiaciones() {
 	c.Data["json"] = response
 }
 
+// ArbolRubroApropiaciones ...
+// @Title ArbolRubroApropiaciones
+// @Description Get Arbol Rubros apropiacion para usar en el cliente presupuesto
+// @Param	unidadEjecutora		path 	int64	true		"unidad ejecutora a consultar"
+// @Param	vigencia		path 	int64	true		"vigencia a consultar"
+// @Param	raiz		path 	int64	true		"raiz a consultar"
+// @Param	nivel		query 	string	false		"nivel a consultar"
+// @Success 200 {object} models.Rubro
+// @Failure 403
+// @router /ArbolRubroApropiacion/:unidadEjecutora/:vigencia/:raiz [get]
+func (c *ApropiacionController) ArbolRubroApropiaciones() {
+
+	ueStr := c.Ctx.Input.Param(":unidadEjecutora")
+	vigenciaStr := c.Ctx.Input.Param(":vigencia")
+	raiz := c.Ctx.Input.Param(":raiz")
+	nivel := c.GetString("nivel")
+	defer func() {
+		if r := recover(); r != nil {
+			beego.Error(r)
+			responseformat.SetResponseFormat(&c.Controller, r, "E_0458", 500)
+		}
+	}()
+
+	arbol, err := apropiacionHelper.ConstruirArbolRubroApropiacion(ueStr, vigenciaStr, raiz, nivel)
+	if err != nil {
+		panic("Mongo API Service Error")
+	}
+	c.Data["json"] = arbol
+	c.ServeJSON()
+}
+
 // SaldoApropiacion ...
 // @Title SaldoApropiacion
 // @Description Get Arbol Rubros By UE

--- a/helpers/apropiacionHelper/apropiacion.helper.go
+++ b/helpers/apropiacionHelper/apropiacion.helper.go
@@ -250,3 +250,52 @@ func PresupuestoAprobado(vigencia, unidadejecutora int) bool {
 	}
 
 }
+
+// ConstruirArbolRubroApropiacion construir abrol rubro apropiacion
+func ConstruirArbolRubroApropiacion(ueStr string, vigenciaStr string, raiz string, nivel string) (resultado map[string]interface{}, err interface{}) {
+	var urlmongo string
+	registros := make([]map[string]interface{}, 0)
+	var res map[string]interface{}
+	var respuesta map[string]interface{}
+
+	urlmongo = beego.AppConfig.String("financieraMongoCurdApiService") + "arbol_rubro_apropiacion/arbol_apropiacion_valores/" + ueStr + "/" + vigenciaStr + "/" + raiz + "?nivel=" + nivel
+	if err := request.GetJson(urlmongo, &res); err != nil {
+		return nil, err
+	}
+	hijosNodo := res["Body"].([]interface{})[0].(map[string]interface{})["data"].(map[string]interface{})["Hijos"]
+	hijos := interfaceToStringArray(hijosNodo)
+	for _, element := range hijos {
+		urlmongo = beego.AppConfig.String("financieraMongoCurdApiService") + "arbol_rubro_apropiacion/arbol_apropiacion_valores/" + ueStr + "/" + vigenciaStr + "/" + element + "?nivel=-1"
+		if err := request.GetJson(urlmongo, &respuesta); err != nil {
+			return nil, err
+		} else {
+			registros = append(registros, respuesta["Body"].([]interface{})[0].(map[string]interface{}))
+		}
+	}
+
+	res["Body"].([]interface{})[0].(map[string]interface{})["children"] = registros
+	return res, err
+
+}
+
+// interfaceToStringArray convierte array de interface{} a string
+func interfaceToStringArray(hijos interface{}) (Hijos []string) {
+	aInterface := hijos.([]interface{})
+	aString := make([]string, len(aInterface))
+	for i, v := range aInterface {
+		aString[i] = v.(string)
+	}
+	return aString
+
+}
+
+// // interfaceToStringArray convierte array de interface{} a string
+// func UnirArbol(registros []map[string]interface{}, ) (resultado map[string]interface{}) {
+// 	aInterface := hijos.([]interface{})
+// 	aString := make([]string, len(aInterface))
+// 	for i, v := range aInterface {
+// 		aString[i] = v.(string)
+// 	}
+// 	return aString
+
+// }

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -10,7 +10,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:AprobacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:AprobacionController"],
         beego.ControllerComments{
             Method: "AprobacionAsignacionInicial",
-            Router: `/AprobacionAsignacionInicial/`,
+            Router: "/AprobacionAsignacionInicial/",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -19,7 +19,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:AprobacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:AprobacionController"],
         beego.ControllerComments{
             Method: "Aprobado",
-            Router: `/Aprobado`,
+            Router: "/Aprobado",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -28,7 +28,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:AprobacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:AprobacionController"],
         beego.ControllerComments{
             Method: "InformacionAsignacionInicial",
-            Router: `/InformacionAsignacionInicial/`,
+            Router: "/InformacionAsignacionInicial/",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -37,7 +37,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ApropiacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ApropiacionController"],
         beego.ControllerComments{
             Method: "Post",
-            Router: `/`,
+            Router: "/",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -46,7 +46,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ApropiacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ApropiacionController"],
         beego.ControllerComments{
             Method: "Put",
-            Router: `/:id/:valor/:vigencia`,
+            Router: "/:id/:valor/:vigencia",
             AllowHTTPMethods: []string{"put"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -55,7 +55,16 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ApropiacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ApropiacionController"],
         beego.ControllerComments{
             Method: "ArbolApropiaciones",
-            Router: `/ArbolApropiaciones/:unidadEjecutora/:vigencia`,
+            Router: "/ArbolApropiaciones/:unidadEjecutora/:vigencia",
+            AllowHTTPMethods: []string{"get"},
+            MethodParams: param.Make(),
+            Filters: nil,
+            Params: nil})
+
+    beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ApropiacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ApropiacionController"],
+        beego.ControllerComments{
+            Method: "ArbolRubroApropiaciones",
+            Router: "/ArbolRubroApropiacion/:unidadEjecutora/:vigencia/:raiz",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -64,7 +73,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ApropiacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ApropiacionController"],
         beego.ControllerComments{
             Method: "SaldoApropiacion",
-            Router: `/SaldoApropiacion/:rubro/:unidadEjecutora/:vigencia`,
+            Router: "/SaldoApropiacion/:rubro/:unidadEjecutora/:vigencia",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -73,7 +82,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CdpController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CdpController"],
         beego.ControllerComments{
             Method: "AprobarCdp",
-            Router: `/aprobar_cdp`,
+            Router: "/aprobar_cdp",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -82,7 +91,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CdpController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CdpController"],
         beego.ControllerComments{
             Method: "ExpedirCdp",
-            Router: `/expedirCDP/:id`,
+            Router: "/expedirCDP/:id",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -91,7 +100,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CdpController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CdpController"],
         beego.ControllerComments{
             Method: "SolicitarCdp",
-            Router: `/solicitarCDP`,
+            Router: "/solicitarCDP",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -100,7 +109,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CrpController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CrpController"],
         beego.ControllerComments{
             Method: "ExpedirCrp",
-            Router: `/expedirCRP/:id`,
+            Router: "/expedirCRP/:id",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -109,7 +118,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CrpController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CrpController"],
         beego.ControllerComments{
             Method: "GetInfoCrp",
-            Router: `/getFullCrp`,
+            Router: "/getFullCrp",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -118,7 +127,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CrpController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:CrpController"],
         beego.ControllerComments{
             Method: "SolicitarCrp",
-            Router: `/solicitarCRP`,
+            Router: "/solicitarCRP",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -127,7 +136,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:FuenteFinanciamientoApropiacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:FuenteFinanciamientoApropiacionController"],
         beego.ControllerComments{
             Method: "Delete",
-            Router: `/:id/:vigencia/:unidadEjecutora`,
+            Router: "/:id/:vigencia/:unidadEjecutora",
             AllowHTTPMethods: []string{"delete"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -136,7 +145,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:FuenteFinanciamientoApropiacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:FuenteFinanciamientoApropiacionController"],
         beego.ControllerComments{
             Method: "RegistrarModificacion",
-            Router: `/modificacion`,
+            Router: "/modificacion",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -145,7 +154,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:FuenteFinanciamientoApropiacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:FuenteFinanciamientoApropiacionController"],
         beego.ControllerComments{
             Method: "GetRubrosbyFuente",
-            Router: `/plan_adquisiciones_rubros_fuente/:vigencia/:id`,
+            Router: "/plan_adquisiciones_rubros_fuente/:vigencia/:id",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -154,7 +163,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:FuenteFinanciamientoApropiacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:FuenteFinanciamientoApropiacionController"],
         beego.ControllerComments{
             Method: "SimulacionAfectacion",
-            Router: `/simulacion_afectacion_modificacion/:centroGestor/:vigencia`,
+            Router: "/simulacion_afectacion_modificacion/:centroGestor/:vigencia",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -163,7 +172,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:FuenteFinanciamientoApropiacionController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:FuenteFinanciamientoApropiacionController"],
         beego.ControllerComments{
             Method: "RegistrarFuenteConApropiacion",
-            Router: `registrar_fuentes_con_apropiacion`,
+            Router: "registrar_fuentes_con_apropiacion",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -172,7 +181,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ModificacionPresupuestalController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ModificacionPresupuestalController"],
         beego.ControllerComments{
             Method: "Post",
-            Router: `/`,
+            Router: "/",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -181,7 +190,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ModificacionPresupuestalController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ModificacionPresupuestalController"],
         beego.ControllerComments{
             Method: "GetAllModificacionPresupuestalByVigenciaAndCG",
-            Router: `/:vigencia/:CG/:tipo`,
+            Router: "/:vigencia/:CG/:tipo",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -190,7 +199,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ModificacionPresupuestalController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ModificacionPresupuestalController"],
         beego.ControllerComments{
             Method: "SimulacionAfectacion",
-            Router: `/simulacion_afectacion_modificacion/:centroGestor/:vigencia`,
+            Router: "/simulacion_afectacion_modificacion/:centroGestor/:vigencia",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -199,7 +208,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ModificacionPresupuestalController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:ModificacionPresupuestalController"],
         beego.ControllerComments{
             Method: "GetOneModificacionPresupuestalByVigenciaAndCG",
-            Router: `get_one/:vigencia/:CG/:UUID`,
+            Router: "get_one/:vigencia/:CG/:UUID",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -208,7 +217,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:MovimientoController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:MovimientoController"],
         beego.ControllerComments{
             Method: "Post",
-            Router: `/`,
+            Router: "/",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -217,7 +226,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:MovimientoController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:MovimientoController"],
         beego.ControllerComments{
             Method: "GetAllAnulacionesByVigenciaCGAndUUID",
-            Router: `/get_doc_by_mov_parentUUID/:vigencia/:CG/:UUID`,
+            Router: "/get_doc_by_mov_parentUUID/:vigencia/:CG/:UUID",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -226,7 +235,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:NecesidadController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:NecesidadController"],
         beego.ControllerComments{
             Method: "GetFullNecesidad",
-            Router: `/getfullnecesidad/:id`,
+            Router: "/getfullnecesidad/:id",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -235,7 +244,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:NecesidadController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:NecesidadController"],
         beego.ControllerComments{
             Method: "PostFullNecesidad",
-            Router: `/post_full_necesidad`,
+            Router: "/post_full_necesidad",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -244,7 +253,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:RubroController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:RubroController"],
         beego.ControllerComments{
             Method: "ArbolRubros",
-            Router: `/ArbolRubros/:unidadEjecutora`,
+            Router: "/ArbolRubros/:unidadEjecutora",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -253,7 +262,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:RubroController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:RubroController"],
         beego.ControllerComments{
             Method: "EliminarRubro",
-            Router: `/EliminarRubro/:id`,
+            Router: "/EliminarRubro/:id",
             AllowHTTPMethods: []string{"delete"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -262,7 +271,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:RubroController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:RubroController"],
         beego.ControllerComments{
             Method: "RegistrarRubro",
-            Router: `/RegistrarRubro/`,
+            Router: "/RegistrarRubro/",
             AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -271,7 +280,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:VigenciaController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:VigenciaController"],
         beego.ControllerComments{
             Method: "CerrarVigencia",
-            Router: `/cerrar_vigencia/:vigencia/:area`,
+            Router: "/cerrar_vigencia/:vigencia/:area",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,
@@ -280,7 +289,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:VigenciaController"] = append(beego.GlobalControllerRouter["github.com/udistrital/plan_cuentas_mid/controllers:VigenciaController"],
         beego.ControllerComments{
             Method: "GetCierreVigencia",
-            Router: `/get_cierre/:vigencia/:area/:cerrada`,
+            Router: "/get_cierre/:vigencia/:area/:cerrada",
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,


### PR DESCRIPTION
…ilizar consulta en el cliente de presupuesto #425

Se crea el siguiente Endpoint encargado de recibir una raíz y construir el árbol de apropiación en base a ella.

El Endpoint se crea con el fin de agilizar las consultas en el cliente presupuesto debido a que hay raíces con 500 hijos o más  y no es posible realizar todas las peticiones desde el cliente.

`http://localhost:8084/v1/apropiacion/ArbolRubroApropiacion/1/2020/3-00-991-00-00-29?nivel=0`

Este Endpoint crear un Array con todos los hijos de una raíz y realiza de manera individual cada consulta evitando que la falle en caso de sobrepasar 1 minuta de espera por petición. 

Se implementa para las raíces 3-00-991-00-00-29 y 2-00-991-00-00-29 que son las que más hijos tienen y en ocasiones el cliente no podía realiza las peticiones 

