### PR TITLE
Cambio de status en no aprobar movimiento

### DIFF
--- a/controllers/necesidad.go
+++ b/controllers/necesidad.go
@@ -109,6 +109,7 @@ func (c *NecesidadController) PostFullNecesidad() {
 // @Param	id		path 	string	true		"The id you want to update"
 // @Param	body		body 	necesidad_models.Necesidad	true		"body for Necesidad content"
 // @Success 200 {object} necesidad_models.Necesidad
+// @Failure 409 No se puede hacer movimiento poque el rubro no tiene monto suficiente
 // @Failure 400 the request contains incorrect syntax
 // @router /:id [put]
 func (c *NecesidadController) Put() {

--- a/helpers/necesidadHelper/movimientopresu.go
+++ b/helpers/necesidadHelper/movimientopresu.go
@@ -46,7 +46,7 @@ func InterceptorMovimientoNecesidad(id int, necesidadent necesidad_models.Necesi
 		} else {
 			outputError = map[string]interface{}{
 				"funcion": "EvaluarMovimiento - Handled Error!",
-				"status":  "452",
+				"status":  "409",
 			}
 		}
 	}

--- a/helpers/necesidadHelper/movimientopresu.go
+++ b/helpers/necesidadHelper/movimientopresu.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/astaxie/beego"
-	"github.com/astaxie/beego/logs"
 	models_movimientos "github.com/udistrital/movimientos_crud/models"
 	necesidad_models "github.com/udistrital/necesidades_crud/models"
 	movimientohelper "github.com/udistrital/plan_cuentas_mid/helpers/movimientoHelper"
@@ -45,6 +44,10 @@ func InterceptorMovimientoNecesidad(id int, necesidadent necesidad_models.Necesi
 				}
 			}
 		} else {
+			outputError = map[string]interface{}{
+				"funcion": "EvaluarMovimiento - Handled Error!",
+				"status":  "452",
+			}
 		}
 	}
 	return
@@ -98,10 +101,8 @@ func RealizarMovimiento(necesidad necesidad_models.Necesidad) (outputError map[s
 								mov1.Mov_Proc_Ext = strconv.Itoa(movimientoext.Id)
 								mov1.Valor = -fuente["MontoParcial"].(float64)
 								mov = append(mov, mov1)
-								if movimientodet, err := movimientohelper.CrearMovimiento(mov); err != nil {
+								if _, err := movimientohelper.CrearMovimiento(mov); err != nil {
 									outputError = err
-								} else {
-									logs.Debug(movimientodet)
 								}
 								mov = nil
 							}
@@ -119,10 +120,8 @@ func RealizarMovimiento(necesidad necesidad_models.Necesidad) (outputError map[s
 						mov1.Mov_Proc_Ext = strconv.Itoa(movimientoext.Id)
 						mov1.Valor = -fuente["MontoParcial"].(float64)
 						mov = append(mov, mov1)
-						if movimientodet, err := movimientohelper.CrearMovimiento(mov); err != nil {
+						if _, err := movimientohelper.CrearMovimiento(mov); err != nil {
 							outputError = err
-						} else {
-							logs.Debug(movimientodet)
 						}
 						mov = nil
 					}
@@ -152,13 +151,13 @@ func EvaluarMovimiento(necesidad necesidad_models.Necesidad) (resultado bool, ou
 		outputError = err
 	} else {
 		if necesidad.TipoFinanciacionNecesidadId.Nombre == "Inversion" {
-			for k1, valor := range response.Rubros {
-				for k2, meta := range valor.Metas {
-					for k3, actividadp := range meta.Actividades {
+			for _, valor := range response.Rubros {
+				for _, meta := range valor.Metas {
+					for _, actividadp := range meta.Actividades {
 						actividad := *actividadp
 						fuentesi := actividad["FuentesActividad"]
 						fuentesp := fuentesi.([]*map[string]interface{})
-						for k4, fuentep := range fuentesp {
+						for _, fuentep := range fuentesp {
 							fuente := *fuentep
 							mov1.Cuen_Pre, _ = utils.Serializar(map[string]interface{}{
 								"RubroId":                valor.RubroId,
@@ -169,12 +168,10 @@ func EvaluarMovimiento(necesidad necesidad_models.Necesidad) (resultado bool, ou
 							if movimientos, err := movimientohelper.ObtenerUltimoMovimiento(mov); err != nil {
 								outputError = err
 							} else {
-								for k5, movimiento := range movimientos {
+								for _, movimiento := range movimientos {
 									if int(movimiento.Saldo) >= int(fuente["MontoParcial"].(float64)) {
 										resultado = true
 									}
-									logs.Debug("EvaluarMovimiento - 4", k1, k2, k3, k4, k5, resultado, movimiento.Saldo, fuente["MontoParcial"])
-
 								}
 							}
 							mov = nil

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1006,6 +1006,9 @@
                     },
                     "400": {
                         "description": "the request contains incorrect syntax"
+                    },
+                    "409": {
+                        "description": "No se puede hacer movimiento poque el rubro no tiene monto suficiente"
                     }
                 }
             }
@@ -1179,63 +1182,63 @@
         }
     },
     "definitions": {
-        "10222.0xc000597b90.false": {
+        "10222.0xc0005539b0.false": {
             "title": "false",
             "type": "object"
         },
-        "10281.string.0xc0005871a0": {
-            "title": "0xc0005871a0",
+        "10281.string.0xc00051df50": {
+            "title": "0xc00051df50",
             "type": "object"
         },
-        "10490.string.0xc000587218": {
-            "title": "0xc000587218",
+        "10490.string.0xc00051dfc8": {
+            "title": "0xc00051dfc8",
             "type": "object"
         },
-        "10558.0xc000597d40.false": {
+        "10558.0xc000553b60.false": {
             "title": "false",
             "type": "object"
         },
-        "10610.string.0xc000587260": {
-            "title": "0xc000587260",
+        "10610.string.0xc00056a018": {
+            "title": "0xc00056a018",
             "type": "object"
         },
-        "10666.string.0xc000587290": {
-            "title": "0xc000587290",
+        "10666.string.0xc00056a048": {
+            "title": "0xc00056a048",
             "type": "object"
         },
-        "10881.string.0xc000587320": {
-            "title": "0xc000587320",
+        "10881.string.0xc00056a0d8": {
+            "title": "0xc00056a0d8",
             "type": "object"
         },
-        "10979.string.0xc000587350": {
-            "title": "0xc000587350",
+        "10979.string.0xc00056a108": {
+            "title": "0xc00056a108",
             "type": "object"
         },
-        "11075.string.0xc000587380": {
-            "title": "0xc000587380",
+        "11075.string.0xc00056a138": {
+            "title": "0xc00056a138",
             "type": "object"
         },
-        "11183.string.0xc0005873b0": {
-            "title": "0xc0005873b0",
+        "11183.string.0xc00056a168": {
+            "title": "0xc00056a168",
             "type": "object"
         },
-        "11281.string.0xc0005873e0": {
-            "title": "0xc0005873e0",
+        "11281.string.0xc00056a198": {
+            "title": "0xc00056a198",
             "type": "object"
         },
-        "11372.string.0xc000587410": {
-            "title": "0xc000587410",
+        "11372.string.0xc00056a1c8": {
+            "title": "0xc00056a1c8",
             "type": "object"
         },
-        "11472.string.0xc000587440": {
-            "title": "0xc000587440",
+        "11472.string.0xc00056a1f8": {
+            "title": "0xc00056a1f8",
             "type": "object"
         },
-        "11571.string.0xc000587470": {
-            "title": "0xc000587470",
+        "11571.string.0xc00056a228": {
+            "title": "0xc00056a228",
             "type": "object"
         },
-        "4594.0xc0005971a0.false": {
+        "4594.0xc000552fc0.false": {
             "title": "false",
             "type": "object"
         },
@@ -1328,7 +1331,7 @@
                     "format": "int64"
                 },
                 "Data": {
-                    "$ref": "#/definitions/4594.0xc0005971a0.false"
+                    "$ref": "#/definitions/4594.0xc000552fc0.false"
                 },
                 "FechaRegistro": {
                     "type": "string"
@@ -1402,7 +1405,7 @@
                 "Actividades": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/10281.string.0xc0005871a0"
+                        "$ref": "#/definitions/10281.string.0xc00051df50"
                     }
                 },
                 "Id": {
@@ -1413,7 +1416,7 @@
                     "type": "string"
                 },
                 "RubroNecesidadId": {
-                    "$ref": "#/definitions/10222.0xc000597b90.false"
+                    "$ref": "#/definitions/10222.0xc0005539b0.false"
                 }
             }
         },
@@ -1677,7 +1680,7 @@
                 "Fuentes": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/10610.string.0xc000587260"
+                        "$ref": "#/definitions/10610.string.0xc00056a018"
                     }
                 },
                 "Id": {
@@ -1685,7 +1688,7 @@
                     "format": "int64"
                 },
                 "InfoRubro": {
-                    "$ref": "#/definitions/10490.string.0xc000587218"
+                    "$ref": "#/definitions/10490.string.0xc00051dfc8"
                 },
                 "Metas": {
                     "type": "array",
@@ -1694,12 +1697,12 @@
                     }
                 },
                 "NecesidadId": {
-                    "$ref": "#/definitions/10558.0xc000597d40.false"
+                    "$ref": "#/definitions/10558.0xc000553b60.false"
                 },
                 "Productos": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/10666.string.0xc000587290"
+                        "$ref": "#/definitions/10666.string.0xc00056a048"
                     }
                 },
                 "RubroId": {
@@ -1805,40 +1808,40 @@
                 "ActividadEconomicaNecesidad": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/11472.string.0xc000587440"
+                        "$ref": "#/definitions/11472.string.0xc00056a1f8"
                     }
                 },
                 "ActividadEspecificaNecesidad": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/11372.string.0xc000587410"
+                        "$ref": "#/definitions/11372.string.0xc00056a1c8"
                     }
                 },
                 "DetallePrestacionServicioNecesidad": {
-                    "$ref": "#/definitions/11075.string.0xc000587380"
+                    "$ref": "#/definitions/11075.string.0xc00056a138"
                 },
                 "DetalleServicioNecesidad": {
-                    "$ref": "#/definitions/10979.string.0xc000587350"
+                    "$ref": "#/definitions/10979.string.0xc00056a108"
                 },
                 "MarcoLegalNecesidad": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/11281.string.0xc0005873e0"
+                        "$ref": "#/definitions/11281.string.0xc00056a198"
                     }
                 },
                 "Necesidad": {
-                    "$ref": "#/definitions/10881.string.0xc000587320"
+                    "$ref": "#/definitions/10881.string.0xc00056a0d8"
                 },
                 "ProductosCatalogoNecesidad": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/11183.string.0xc0005873b0"
+                        "$ref": "#/definitions/11183.string.0xc00056a168"
                     }
                 },
                 "RequisitoMinimoNecesidad": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/11571.string.0xc000587470"
+                        "$ref": "#/definitions/11571.string.0xc00056a228"
                     }
                 },
                 "Rubros": {

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -634,6 +634,9 @@ paths:
             $ref: '#/definitions/necesidad_models.Necesidad'
         "400":
           description: the request contains incorrect syntax
+        "409":
+          description: No se puede hacer movimiento poque el rubro no tiene monto
+            suficiente
   /necesidad/getfullnecesidad/{id}:
     get:
       tags:
@@ -785,50 +788,50 @@ paths:
           schema:
             $ref: '#/definitions/models.SolicitudCDP'
 definitions:
-  4594.0xc0005971a0.false:
+  4594.0xc000552fc0.false:
     title: "false"
     type: object
-  10222.0xc000597b90.false:
+  10222.0xc0005539b0.false:
     title: "false"
     type: object
-  10281.string.0xc0005871a0:
-    title: "0xc0005871a0"
+  10281.string.0xc00051df50:
+    title: "0xc00051df50"
     type: object
-  10490.string.0xc000587218:
-    title: "0xc000587218"
+  10490.string.0xc00051dfc8:
+    title: "0xc00051dfc8"
     type: object
-  10558.0xc000597d40.false:
+  10558.0xc000553b60.false:
     title: "false"
     type: object
-  10610.string.0xc000587260:
-    title: "0xc000587260"
+  10610.string.0xc00056a018:
+    title: "0xc00056a018"
     type: object
-  10666.string.0xc000587290:
-    title: "0xc000587290"
+  10666.string.0xc00056a048:
+    title: "0xc00056a048"
     type: object
-  10881.string.0xc000587320:
-    title: "0xc000587320"
+  10881.string.0xc00056a0d8:
+    title: "0xc00056a0d8"
     type: object
-  10979.string.0xc000587350:
-    title: "0xc000587350"
+  10979.string.0xc00056a108:
+    title: "0xc00056a108"
     type: object
-  11075.string.0xc000587380:
-    title: "0xc000587380"
+  11075.string.0xc00056a138:
+    title: "0xc00056a138"
     type: object
-  11183.string.0xc0005873b0:
-    title: "0xc0005873b0"
+  11183.string.0xc00056a168:
+    title: "0xc00056a168"
     type: object
-  11281.string.0xc0005873e0:
-    title: "0xc0005873e0"
+  11281.string.0xc00056a198:
+    title: "0xc00056a198"
     type: object
-  11372.string.0xc000587410:
-    title: "0xc000587410"
+  11372.string.0xc00056a1c8:
+    title: "0xc00056a1c8"
     type: object
-  11472.string.0xc000587440:
-    title: "0xc000587440"
+  11472.string.0xc00056a1f8:
+    title: "0xc00056a1f8"
     type: object
-  11571.string.0xc000587470:
-    title: "0xc000587470"
+  11571.string.0xc00056a228:
+    title: "0xc00056a228"
     type: object
   models.Alert:
     title: Alert
@@ -896,7 +899,7 @@ definitions:
         type: integer
         format: int64
       Data:
-        $ref: '#/definitions/4594.0xc0005971a0.false'
+        $ref: '#/definitions/4594.0xc000552fc0.false'
       FechaRegistro:
         type: string
       Tipo:
@@ -946,14 +949,14 @@ definitions:
       Actividades:
         type: array
         items:
-          $ref: '#/definitions/10281.string.0xc0005871a0'
+          $ref: '#/definitions/10281.string.0xc00051df50'
       Id:
         type: integer
         format: int64
       MetaId:
         type: string
       RubroNecesidadId:
-        $ref: '#/definitions/10222.0xc000597b90.false'
+        $ref: '#/definitions/10222.0xc0005539b0.false'
   models.ModificacionFuenteReceiver:
     title: ModificacionFuenteReceiver
     type: object
@@ -1135,22 +1138,22 @@ definitions:
       Fuentes:
         type: array
         items:
-          $ref: '#/definitions/10610.string.0xc000587260'
+          $ref: '#/definitions/10610.string.0xc00056a018'
       Id:
         type: integer
         format: int64
       InfoRubro:
-        $ref: '#/definitions/10490.string.0xc000587218'
+        $ref: '#/definitions/10490.string.0xc00051dfc8'
       Metas:
         type: array
         items:
           $ref: '#/definitions/models.MetaRubroNecesidad'
       NecesidadId:
-        $ref: '#/definitions/10558.0xc000597d40.false'
+        $ref: '#/definitions/10558.0xc000553b60.false'
       Productos:
         type: array
         items:
-          $ref: '#/definitions/10666.string.0xc000587290'
+          $ref: '#/definitions/10666.string.0xc00056a048'
       RubroId:
         type: string
   models.SolicitudCDP:
@@ -1224,29 +1227,29 @@ definitions:
       ActividadEconomicaNecesidad:
         type: array
         items:
-          $ref: '#/definitions/11472.string.0xc000587440'
+          $ref: '#/definitions/11472.string.0xc00056a1f8'
       ActividadEspecificaNecesidad:
         type: array
         items:
-          $ref: '#/definitions/11372.string.0xc000587410'
+          $ref: '#/definitions/11372.string.0xc00056a1c8'
       DetallePrestacionServicioNecesidad:
-        $ref: '#/definitions/11075.string.0xc000587380'
+        $ref: '#/definitions/11075.string.0xc00056a138'
       DetalleServicioNecesidad:
-        $ref: '#/definitions/10979.string.0xc000587350'
+        $ref: '#/definitions/10979.string.0xc00056a108'
       MarcoLegalNecesidad:
         type: array
         items:
-          $ref: '#/definitions/11281.string.0xc0005873e0'
+          $ref: '#/definitions/11281.string.0xc00056a198'
       Necesidad:
-        $ref: '#/definitions/10881.string.0xc000587320'
+        $ref: '#/definitions/10881.string.0xc00056a0d8'
       ProductosCatalogoNecesidad:
         type: array
         items:
-          $ref: '#/definitions/11183.string.0xc0005873b0'
+          $ref: '#/definitions/11183.string.0xc00056a168'
       RequisitoMinimoNecesidad:
         type: array
         items:
-          $ref: '#/definitions/11571.string.0xc000587470'
+          $ref: '#/definitions/11571.string.0xc00056a228'
       Rubros:
         type: array
         items:


### PR DESCRIPTION
Se ajusto en el interceptor en caso de que el movimiento no pueda ser realizado, devolver un status personalizado (452) para que el cliente detecte la alerta de no crear por evaluar movimiento, ademas se limpio codigo que sobraba en el mid.

https://github.com/udistrital/necesidades_cliente/issues/303